### PR TITLE
Create location and reward

### DIFF
--- a/api/prisma/migrations/20240326004539_add_created_at_and_updated_at/migration.sql
+++ b/api/prisma/migrations/20240326004539_add_created_at_and_updated_at/migration.sql
@@ -1,0 +1,29 @@
+/*
+  Warnings:
+
+  - Added the required column `updatedAt` to the `Comment` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Location` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Permission` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Reward` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `updatedAt` to the `Species` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Comment" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Location" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Permission" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Reward" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;
+
+-- AlterTable
+ALTER TABLE "Species" ADD COLUMN     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ADD COLUMN     "updatedAt" TIMESTAMP(3) NOT NULL;

--- a/api/prisma/migrations/20240326013134_add_longitude_latitude_description/migration.sql
+++ b/api/prisma/migrations/20240326013134_add_longitude_latitude_description/migration.sql
@@ -1,0 +1,12 @@
+/*
+  Warnings:
+
+  - Added the required column `description` to the `Location` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `latitude` to the `Location` table without a default value. This is not possible if the table is not empty.
+  - Added the required column `longitude` to the `Location` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Location" ADD COLUMN     "description" TEXT NOT NULL,
+ADD COLUMN     "latitude" DOUBLE PRECISION NOT NULL,
+ADD COLUMN     "longitude" DOUBLE PRECISION NOT NULL;

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -81,6 +81,9 @@ model Location {
   address String
   city    String
   country String
+  latitude  Float
+  longitude Float
+  description String
   createdAt DateTime  @default(now())
   updatedAt DateTime  @updatedAt
   isDeleted Boolean   @default(false)

--- a/api/prisma/schema.prisma
+++ b/api/prisma/schema.prisma
@@ -50,6 +50,8 @@ model Reward {
   description String
   petId       Int
   locationId  Int
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   isDeleted Boolean    @default(false)
   pet         Pet      @relation(fields: [petId], references: [id])
   location    Location @relation(fields: [locationId], references: [id])
@@ -59,6 +61,8 @@ model Reward {
 model Permission {
   id    Int    @id @default(autoincrement())
   name  String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   isDeleted Boolean   @default(false)
   users User[]
 }
@@ -66,6 +70,8 @@ model Permission {
 model Species {
   id   Int    @id @default(autoincrement())
   name String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   isDeleted Boolean   @default(false)
   pets Pet[]
 }
@@ -75,6 +81,8 @@ model Location {
   address String
   city    String
   country String
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   isDeleted Boolean   @default(false)
   Reward  Reward[]
 }
@@ -84,6 +92,8 @@ model Comment {
   text   String
   userId Int
   rewardId   Int
+  createdAt DateTime  @default(now())
+  updatedAt DateTime  @updatedAt
   isDeleted Boolean   @default(false)
   user   User   @relation(fields: [userId], references: [id])
   reward     Reward    @relation(fields: [rewardId], references: [id])

--- a/api/prisma/seed/data.ts
+++ b/api/prisma/seed/data.ts
@@ -794,36 +794,239 @@ export const seedData = {
     },
   ],
   locations: [
-    { address: "123 Main St", city: "Anytown", country: "CountryA" },
-    { address: "456 Elm St", city: "Otherville", country: "CountryB" },
-    { address: "789 Oak St", city: "Sometown", country: "CountryC" },
-    { address: "101 Pine St", city: "Elsewhere", country: "CountryD" },
-    { address: "202 Maple St", city: "Thisplace", country: "CountryE" },
-    { address: "303 Birch St", city: "Thatplace", country: "CountryF" },
-    { address: "404 Cedar St", city: "Hereville", country: "CountryG" },
-    { address: "505 Redwood St", city: "Thereville", country: "CountryH" },
-    { address: "606 Willow St", city: "Everywhere", country: "CountryI" },
-    { address: "707 Palm St", city: "Nowhere", country: "CountryJ" },
-    { address: "808 Magnolia St", city: "Somewhere", country: "CountryK" },
-    { address: "909 Cherry St", city: "Whoville", country: "CountryL" },
-    { address: "1010 Apple St", city: "Howtown", country: "CountryM" },
-    { address: "1111 Orange St", city: "Whyville", country: "CountryN" },
-    { address: "1212 Banana St", city: "Whatcity", country: "CountryO" },
-    { address: "456 Elm St", city: "Springfield", country: "USA" },
-    { address: "789 Pine St", city: "Greendale", country: "USA" },
-    { address: "101 Maple Ave", city: "Shelbyville", country: "USA" },
-    { address: "202 Oak St", city: "Riverdale", country: "USA" },
-    { address: "303 Birch Ln", city: "Centerville", country: "USA" },
-    { address: "404 Cedar Rd", city: "Smallville", country: "USA" },
-    { address: "505 Walnut St", city: "Metropolis", country: "USA" },
-    { address: "606 Chestnut Ave", city: "Star City", country: "USA" },
-    { address: "707 Aspen Pl", city: "Coast City", country: "USA" },
-    { address: "808 Magnolia Blvd", city: "Gotham", country: "USA" },
-    { address: "909 Redwood St", city: "Central City", country: "USA" },
-    { address: "1010 Sequoia St", city: "National City", country: "USA" },
-    { address: "1111 Willow St", city: "Starling City", country: "USA" },
-    { address: "1313 Peachtree Ln", city: "Midway City", country: "USA" },
-    { address: "1212 Cherry St", city: "Hub City", country: "USA" },
+    {
+      address: "123 Main St",
+      city: "Anytown",
+      country: "CountryA",
+      latitude: -42.14557,
+      longitude: 111.4957,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "456 Elm St",
+      city: "Otherville",
+      country: "CountryB",
+      latitude: 44.00748,
+      longitude: -36.76434,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "789 Oak St",
+      city: "Sometown",
+      country: "CountryC",
+      latitude: -5.40876,
+      longitude: -127.23305,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "101 Pine St",
+      city: "Elsewhere",
+      country: "CountryD",
+      latitude: -65.5082,
+      longitude: 167.4548,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "202 Maple St",
+      city: "Thisplace",
+      country: "CountryE",
+      latitude: 1.03424,
+      longitude: 144.09766,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "404 Cedar St",
+      city: "Hereville",
+      country: "CountryG",
+      latitude: -18.80893,
+      longitude: 116.89981,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "505 Redwood St",
+      city: "Thereville",
+      country: "CountryH",
+      latitude: -69.76192,
+      longitude: -39.33322,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "606 Willow St",
+      city: "Everywhere",
+      country: "CountryI",
+      latitude: -63.26238,
+      longitude: 167.63485,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "707 Palm St",
+      city: "Nowhere",
+      country: "CountryJ",
+      latitude: -72.94048,
+      longitude: 73.82097,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "808 Magnolia St",
+      city: "Somewhere",
+      country: "CountryK",
+      latitude: 31.7856,
+      longitude: -94.08729,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "909 Cherry St",
+      city: "Whoville",
+      country: "CountryL",
+      latitude: -22.56943,
+      longitude: 57.15176,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "1010 Apple St",
+      city: "Howtown",
+      country: "CountryM",
+      latitude: 65.02725,
+      longitude: 84.08905,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "1111 Orange St",
+      city: "Whyville",
+      country: "CountryN",
+      latitude: -87.17042,
+      longitude: 80.71457,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "1212 Banana St",
+      city: "Whatcity",
+      country: "CountryO",
+      latitude: 8.94596,
+      longitude: 45.4412,
+      description: "A picturesque setting with unique cultural charm."
+    },
+    {
+      address: "456 Elm St",
+      city: "Springfield",
+      country: "USA",
+      latitude: -16.4346,
+      longitude: -101.54285,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "789 Pine St",
+      city: "Greendale",
+      country: "USA",
+      latitude: 17.47627,
+      longitude: -42.5676,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "101 Maple Ave",
+      city: "Shelbyville",
+      country: "USA",
+      latitude: -18.1719,
+      longitude: -13.88065,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "202 Oak St",
+      city: "Riverdale",
+      country: "USA",
+      latitude: 79.02519,
+      longitude: -168.76802,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "303 Birch Ln",
+      city: "Centerville",
+      country: "USA",
+      latitude: 4.36343,
+      longitude: 151.49414,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "404 Cedar Rd",
+      city: "Smallville",
+      country: "USA",
+      latitude: -18.98823,
+      longitude: 152.15991,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "505 Walnut St",
+      city: "Metropolis",
+      country: "USA",
+      latitude: 86.05052,
+      longitude: -3.93496,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "606 Chestnut Ave",
+      city: "Star City",
+      country: "USA",
+      latitude: -12.61491,
+      longitude: 143.99113,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "707 Aspen Pl",
+      city: "Coast City",
+      country: "USA",
+      latitude: 77.78956,
+      longitude: 14.00453,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "808 Magnolia Blvd",
+      city: "Gotham",
+      country: "USA",
+      latitude: -61.08197,
+      longitude: -141.93679,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "909 Redwood St",
+      city: "Central City",
+      country: "USA",
+      latitude: 6.11572,
+      longitude: 19.72404,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "1010 Sequoia St",
+      city: "National City",
+      country: "USA",
+      latitude: -38.0855,
+      longitude: -172.36966,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "1111 Willow St",
+      city: "Starling City",
+      country: "USA",
+      latitude: -87.59451,
+      longitude: 15.10425,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "1313 Peachtree Ln",
+      city: "Midway City",
+      country: "USA",
+      latitude: -86.91119,
+      longitude: -161.50206,
+      description: "A bustling location full of life and diversity."
+    },
+    {
+      address: "1212 Cherry St",
+      city: "Hub City",
+      country: "USA",
+      latitude: -80.08386,
+      longitude: 5.46654,
+      description: "A bustling location full of life and diversity."
+    },
+    
   ],
   rewards: [
     {

--- a/api/src/domain/datasources/location.datasource.ts
+++ b/api/src/domain/datasources/location.datasource.ts
@@ -1,0 +1,10 @@
+import { CreateLocationDto } from "../dtos/locations/create-location.dto";
+import { UpdateLocationDto } from "../dtos/locations/update-location.dto";
+import { LocationEntity } from "../entities/location.entity";
+
+
+export abstract class LocationDatasource {
+    abstract create(createLocationDto: CreateLocationDto): Promise<LocationEntity>;
+    abstract update(updateLocationDto: UpdateLocationDto): Promise<LocationEntity>;
+    abstract deleteHardById(id: number): Promise<LocationEntity>;
+}

--- a/api/src/domain/datasources/reward.datasource.ts
+++ b/api/src/domain/datasources/reward.datasource.ts
@@ -1,0 +1,13 @@
+import { CreateRewardDto } from "../dtos/rewards/create-reward.dto";
+import { UpdateRewardDto } from "../dtos/rewards/update-reward.dto";
+import { RewardEntity } from "../entities/reward.entity";
+import { PaginatedRewardResponse } from "../interfaces/paginated-reward-res.interface";
+
+
+export abstract class RewardDatasource {
+    
+    abstract getAll(): Promise<PaginatedRewardResponse>;
+    abstract create(createRewardDto: CreateRewardDto): Promise<RewardEntity>;
+    abstract updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity>;
+    abstract deleteById(id: number): Promise<RewardEntity>;
+}

--- a/api/src/domain/dtos/locations/create-location.dto.ts
+++ b/api/src/domain/dtos/locations/create-location.dto.ts
@@ -1,0 +1,65 @@
+export interface ICreateLocationDto {
+    address: string;
+    city: string;
+    country: string;
+    latitude: number;
+    longitude: number;
+    description: string;
+}
+
+export class CreateLocationDto {
+    public address: string;
+    public city: string;
+    public country: string;
+    public latitude: number;
+    public longitude: number;
+    public description: string;
+
+    constructor(createLocationDto: ICreateLocationDto) {
+        const { address, city, country, latitude, longitude, description } = createLocationDto;
+
+        this.address = address;
+        this.city = city;
+        this.country = country;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.description = description;
+    }
+
+    static create(object: { [key: string]: any }): [string?, CreateLocationDto?] {
+        const { address, city, country, latitude, longitude, description } = object;
+
+        if (!address) return ["Missing address"];
+        if (typeof address !== "string") return ["Address must be a string"];
+        if (address.trim().length === 0) return ["Address cannot be empty"];
+        if (address.trim().length > 255) return ["Address cannot be longer than 255 characters"];
+
+
+        if (!city) return ["Missing city"];
+        if (typeof city !== "string") return ["City must be a string"];
+        if (city.trim().length === 0) return ["City cannot be empty"];
+        if (city.trim().length > 50) return ["City cannot be longer than 50 characters"];
+
+        if (!country) return ["Missing country"];
+        if (typeof country !== "string") return ["Country must be a string"];
+        if (country.trim().length === 0) return ["Country cannot be empty"];
+        if (country.trim().length > 50) return ["Country cannot be longer than 50 characters"];
+
+        if (!latitude) return ["Missing latitude"];
+        if (isNaN(latitude)) return ["Latitude must be a valid number"];
+
+        if (!longitude) return ["Missing longitude"];
+        if (isNaN(longitude)) return ["Longitude must be a valid number"];
+
+        if (!description) return ["Missing description"];
+        if (typeof description !== "string") return ["Description must be a string"];
+        if (description.trim().length === 0) return ["Description cannot be empty"];
+        if (description.trim().length > 255) return ["Description cannot be longer than 255 characters"];
+        
+
+        return [
+            undefined,
+            new CreateLocationDto({ address, city, country, latitude, longitude, description })
+        ];
+    }
+}

--- a/api/src/domain/dtos/locations/update-location.dto.ts
+++ b/api/src/domain/dtos/locations/update-location.dto.ts
@@ -1,0 +1,96 @@
+export interface IUpdateLocationDto {
+    id: number,
+    address?: string,
+    city?: string,
+    country?: string,
+    latitude?: number,
+    longitude?: number,
+    description?: string,
+}
+
+
+export class UpdateLocationDto {
+
+    public id: number;
+    public address?: string;
+    public city?: string;
+    public country?: string;
+    public latitude?: number;
+    public longitude?: number;
+    public description?: string;
+
+    constructor(updateLocationDto: IUpdateLocationDto) {
+        const {
+            id,
+            address,
+            city,
+            country,
+            latitude,
+            longitude,
+            description
+        } = updateLocationDto;
+
+        this.id = id;
+        this.address = address;
+        this.city = city;
+        this.country = country;
+        this.latitude = latitude;
+        this.longitude = longitude;
+        this.description = description;
+    }
+
+    get values() {
+        const returnObj: { [key: string]: any } = {};
+
+        if (this.address) returnObj.address = this.address;
+        if (this.city) returnObj.city = this.city;
+        if (this.country) returnObj.country = this.country;
+        if (this.latitude) returnObj.latitude = this.latitude;
+        if (this.longitude) returnObj.longitude = this.longitude;
+        if (this.description) returnObj.description = this.description;
+
+        return returnObj;
+    }
+
+    static create(object: { [key: string]: any }): [string?, UpdateLocationDto?] {
+        const { id, address, city, country, latitude, longitude, description } = object;
+
+        if (!id) return ['id must be a valid number'];
+        if (isNaN(id)) return ['id must be a valid number'];
+
+        if (address && typeof address !== 'string') return ['Address must be a string'];
+        if (address && address.trim().length === 0) return ['Address cannot be empty'];
+        if (address && address.trim().length > 255) return ['Address cannot be longer than 255 characters'];
+
+        if (city && typeof city !== 'string') return ['City must be a string'];
+        if (city && city.trim().length === 0) return ['City cannot be empty'];
+        if (city && city.trim().length > 50) return ['City cannot be longer than 50 characters'];
+
+        if (country && typeof country !== 'string') return ['Country must be a string'];
+        if (country && country.trim().length === 0) return ['Country cannot be empty'];
+        if (country && country.trim().length > 50) return ['Country cannot be longer than 50 characters'];
+
+        if (latitude && isNaN(latitude)) return ['Latitude must be a valid number'];
+
+        if (longitude && isNaN(longitude)) return ['Longitude must be a valid number'];
+
+        if (description && typeof description !== 'string') return ['Description must be a string'];
+        if (description && description.trim().length === 0) return ['Description cannot be empty'];
+        if (description && description.trim().length > 255) return ['Description cannot be longer than 255 characters'];
+
+
+        return [
+            undefined,
+            new UpdateLocationDto({
+                id,
+                address,
+                city,
+                country,
+                latitude,
+                longitude,
+                description
+            })
+        ];
+    }
+
+}

--- a/api/src/domain/dtos/rewards/create-reward.dto.ts
+++ b/api/src/domain/dtos/rewards/create-reward.dto.ts
@@ -1,0 +1,47 @@
+
+export interface ICreateRewardDto {
+    amount: number,
+    description: string,
+    petId: number,
+    locationId: number,
+};
+
+
+export class CreateRewardDto {
+
+    public amount: number;
+    public description: string;
+    public petId: number;
+    public locationId: number;
+
+    constructor(rewardData: ICreateRewardDto) {
+        this.amount = rewardData.amount;
+        this.description = rewardData.description;
+        this.petId = rewardData.petId;
+        this.locationId = rewardData.locationId;
+    };
+
+    static create(object: { [key: string]: any }): [string?, CreateRewardDto?] {
+            
+            const { amount, description, petId, locationId } = object;
+    
+            if (!amount) return ['Missing amount'];
+            if (isNaN(amount)) return ['amount must be a valid number'];
+    
+            if (!description) return ['Missing description'];
+            if (typeof description !== 'string') return ['Description must be a string'];
+            if (description.trim().length < 20 || description.trim().length > 200) return ['Description must be between 20 and 200 characters'];
+    
+            if (!petId) return ['Missing pet id'];
+            if (isNaN(petId)) return ['Pet id must be a valid number'];
+    
+            if (!locationId) return ['Missing location id'];
+            if (isNaN(locationId)) return ['Location id must be a valid number'];
+    
+            return [
+                undefined,
+                new CreateRewardDto({ amount, description, petId, locationId })
+            ]
+        }
+
+}

--- a/api/src/domain/dtos/rewards/update-reward.dto.ts
+++ b/api/src/domain/dtos/rewards/update-reward.dto.ts
@@ -1,0 +1,44 @@
+
+
+export class UpdateRewardDto {
+
+    private constructor(
+        public id: number,
+        public amount?: number,
+        public description?: string,
+        public petId?: number,
+        public locationId?: number,
+    ){}
+        
+    get values() { 
+
+        const returnObj: {[key: string]:any} = {};
+
+        if(this.amount) returnObj.amount = this.amount;
+        if(this.description) returnObj.description = this.description;
+        if(this.petId) returnObj.petId = this.petId;
+        if(this.locationId) returnObj.locationId = this.locationId;
+
+        return returnObj;
+    }
+
+    static create(object: { [key: string]: any }): [string?, UpdateRewardDto?] {
+
+        const { id, amount, description, petId, locationId } = object; 
+
+        if(!id || isNaN(id)) return ['id must be a valid number']
+        
+        if(amount && isNaN(amount)) return ['amount must be a valid number'];
+        if(amount && amount < 0) return ['amount cannot be negative'];
+        
+        if(description && typeof description !== 'string') return ['Description must be a string'];
+        if(description && description.trim().length < 20) return ['Description must be at least 20 characters'];
+        if(description && description.trim().length > 200) return ['Description cannot be longer than 200 characters'];
+        
+        if(petId && isNaN(petId)) return ['petId must be a valid number']
+        
+        if(locationId && isNaN(locationId)) return ['locationId must be a valid number']
+        
+        return [undefined, new UpdateRewardDto(id, amount, description, petId, locationId)];
+    }
+}

--- a/api/src/domain/entities/comment.entity.ts
+++ b/api/src/domain/entities/comment.entity.ts
@@ -1,0 +1,49 @@
+export interface ICommentEntity {
+    id: number;
+    text: string;
+    userId: number;
+    rewardId: number;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+export class CommentEntity {
+
+    public id: number;
+    public text: string;
+    public userId: number;
+    public rewardId: number;
+    public createdAt: Date;
+    public updatedAt: Date;
+
+    constructor(commentData: ICommentEntity) {
+        const { id, text, userId, rewardId, createdAt, updatedAt } = commentData;
+
+        this.id = id;
+        this.text = text;
+        this.userId = userId;
+        this.rewardId = rewardId;
+        this.createdAt = createdAt;
+        this.updatedAt = updatedAt;
+    };
+
+    static fromObject(object: {[key: string]:any}): CommentEntity {
+        const { id, _id, text, userId, rewardId, createdAt, updatedAt } = object;
+
+        if (!id && !_id) throw new Error('Missing comment id');
+        if (!text) throw new Error('Missing text');
+        if (!userId) throw new Error('Missing userId');
+        if (!rewardId) throw new Error('Missing rewardId');
+        if (!createdAt) throw new Error('Missing createdAt');
+        if (!updatedAt) throw new Error('Missing updatedAt');
+
+        return new CommentEntity({
+            id: id || _id,
+            text,
+            userId,
+            rewardId,
+            createdAt,
+            updatedAt,
+        });
+    }
+}

--- a/api/src/domain/entities/location.entity.ts
+++ b/api/src/domain/entities/location.entity.ts
@@ -1,0 +1,77 @@
+export interface ILocationEntity {
+    id: number;
+    address: string;
+    city: string;
+    country: string; 
+    latitude: number;
+    longitude: number;
+    description: string;
+    createdAt: Date;
+    updatedAt: Date;
+}
+
+
+export class LocationEntity {
+
+    public id: number;
+    public address: string;
+    public city: string;
+    public country: string;
+    public createdAt: Date;
+    public updatedAt: Date;
+    public latitude: number;
+    public longitude: number;
+    public description: string;
+
+    constructor(locationData: ILocationEntity) {
+       
+        this.id = locationData.id;
+        this.address = locationData.address;
+        this.city = locationData.city;
+        this.country = locationData.country;
+        this.createdAt = locationData.createdAt;
+        this.updatedAt = locationData.updatedAt;
+        this.latitude = locationData.latitude;
+        this.longitude = locationData.longitude;
+        this.description = locationData.description;
+    };
+
+    static fromObject(object: {[key: string]:any}): LocationEntity {
+        const {
+            id, 
+            _id, 
+            address, 
+            city, country, 
+            createdAt, 
+            updatedAt,
+            latitude,
+            longitude,
+            description,
+        } = object;
+
+        if (!id && !_id) throw new Error('Missing location id');
+        if (!address) throw new Error('Missing address');
+        if (!city) throw new Error('Missing city');
+        if (!country) throw new Error('Missing country');
+        if (!createdAt) throw new Error('Missing createdAt');
+        if (!updatedAt) throw new Error('Missing updatedAt');
+        if (!latitude) throw new Error('Missing latitude');
+        if (isNaN(latitude)) throw new Error('Latitude must be a valid number');
+        if (!longitude) throw new Error('Missing longitude');
+        if (isNaN(longitude)) throw new Error('Longitude must be a valid number');
+        if (!description) throw new Error('Missing description');
+
+
+        return new LocationEntity({
+            id: id || _id,
+            address,
+            city,
+            country,
+            latitude,
+            longitude,
+            description,
+            createdAt,
+            updatedAt,
+        });
+    }
+}

--- a/api/src/domain/entities/reward.entity.ts
+++ b/api/src/domain/entities/reward.entity.ts
@@ -1,0 +1,90 @@
+import { CommentEntity } from "./comment.entity";
+import { LocationEntity } from "./location.entity";
+import { PetEntity } from "./pet.entity";
+
+export interface IRewardEntity {
+    id: number;
+    amount: number;
+    description: string;
+    pet: PetEntity;
+    createdAt: Date;
+    updatedAt: Date;
+    comments: CommentEntity[];
+    location: LocationEntity;
+}
+
+export class RewardEntity {
+    public id: number;
+    public amount: number;
+    public description: string;
+    public pet: PetEntity;
+    public createdAt: Date;
+    public updatedAt: Date;
+    public comments: CommentEntity[];
+    public location: LocationEntity;
+
+    constructor(rewardData: IRewardEntity) {
+        const {
+        id,
+        amount,
+        description,
+        pet,
+        comments,
+        createdAt,
+        location,
+        updatedAt,
+        } = rewardData;
+
+        this.id = id;
+        this.amount = amount;
+        this.description = description;
+        this.pet = pet;
+        this.comments = comments;
+        this.createdAt = createdAt;
+        this.location = location;
+        this.updatedAt = updatedAt;
+    }
+
+    static fromObject(object: { [key: string]: any }): RewardEntity {
+        const { id, _id, amount, description, pet, createdAt, updatedAt, location, comments } = object;
+
+        if (!id && _id) throw new Error("Missing reward id");
+
+        if (id && isNaN(id)) throw new Error("Reward id must be a valid number");
+        if (_id && isNaN(_id)) throw new Error("Reward id must be a valid number");
+
+        if (!amount) throw new Error("Missing amount");
+        if (isNaN(amount)) throw new Error("amount must be a valid number");
+
+        if (!description) throw new Error("Missing description");
+        if (typeof description !== "string") throw new Error("Description must be a string");
+        if (description.trim().length < 20 || description.trim().length > 200) throw new Error("Description must be between 20 and 200 characters");
+
+        if (!pet) throw new Error("Missing pet");
+        if (typeof pet !== "object") throw new Error("Pet must be an object");
+
+        if (!createdAt) throw new Error("Missing createdAt");
+        if (isNaN(Date.parse(createdAt))) throw new Error("createdAt must be a valid date");
+
+        if (!updatedAt) throw new Error("Missing updatedAt");
+        if (isNaN(Date.parse(updatedAt))) throw new Error("updatedAt must be a valid date");
+
+        if (!location) throw new Error("Missing location");
+        if (typeof location !== "object") throw new Error("Location must be an object");
+
+        if (!comments) throw new Error("Missing comments");
+        if (!Array.isArray(comments)) throw new Error("Comments must be an array");
+
+
+        return new RewardEntity({
+            id: id || _id,
+            amount,
+            description,
+            pet,
+            createdAt,
+            updatedAt,
+            comments,
+            location,
+        });
+    }
+}

--- a/api/src/domain/index.ts
+++ b/api/src/domain/index.ts
@@ -1,4 +1,3 @@
-import exp from 'constants';
 
 // Custom Errors
 export * from './errors/custom.error';
@@ -9,18 +8,24 @@ export * from './entities/pet.entity';
 export * from './entities/user.entity';
 export * from './entities/permission.entity';
 export * from './entities/species.entity';
+export * from './entities/reward.entity';
+export * from './entities/location.entity';
 
 // Repositories
 export * from './repositories/pet.repository';
 export * from './repositories/permission.repository';
 export * from './repositories/user.repository';
 export * from './repositories/species.repository';
+export * from './repositories/reward.repository';
+export * from './repositories/location.repository';
 
 // Data Sources
 export * from './datasources/pet.datasource';
 export * from './datasources/user.datasource';
 export * from './datasources/permission.datasource';
 export * from './datasources/species.datasource';
+export * from './datasources/reward.datasource';
+export * from './datasources/location.datasource';
 
 // DTOs (Data Transfer Objects)
 export * from './dtos/pets/create-pet.dto';
@@ -35,6 +40,10 @@ export * from './dtos/users/update-permissions.dto';
 export * from './dtos/users/user-response.dto';
 export * from './dtos/species/create-species.dto';
 export * from './dtos/species/update-species.dto';
+export * from './dtos/rewards/create-reward.dto';
+export * from './dtos/rewards/update-reward.dto';
+export * from './dtos/locations/create-location.dto';
+export * from './dtos/locations/update-location.dto';
 
 // Interfaces
 export * from './interfaces';
@@ -44,6 +53,9 @@ export * from './interfaces/user-search-criteria.interface';
 export * from './interfaces/paginated-pet-res.interface';
 export * from './interfaces/send-mail-options.interface';
 export * from './interfaces/attachement.interface';
+export * from './interfaces/paginated-species-res.interface';
+export * from './interfaces/paginated-permission-res.interface';
+export * from './interfaces/paginated-reward-res.interface';
 
 // Use cases
 export * from './use-cases/user/create-user';
@@ -67,6 +79,9 @@ export * from './use-cases/pet/create-pet';
 export * from './use-cases/pet/delete-pet';
 export * from './use-cases/pet/get-user-pets';
 export * from './use-cases/pet/update-pet';
+export * from './use-cases/location/create-location';
+export * from './use-cases/reward/create-reward';
 
 // Services
 export * from './services/email-service';
+export * from './services/reward-service';

--- a/api/src/domain/interfaces/paginated-reward-res.interface.ts
+++ b/api/src/domain/interfaces/paginated-reward-res.interface.ts
@@ -1,0 +1,10 @@
+import { RewardEntity } from "../entities/reward.entity";
+
+export interface PaginatedRewardResponse {
+    page: number;
+    limit: number;
+    total: number;
+    next: string | null;
+    prev: string | null;
+    rewards: RewardEntity[];
+}

--- a/api/src/domain/repositories/location.repository.ts
+++ b/api/src/domain/repositories/location.repository.ts
@@ -1,0 +1,10 @@
+import { CreateLocationDto } from "../dtos/locations/create-location.dto";
+import { UpdateLocationDto } from "../dtos/locations/update-location.dto";
+import { LocationEntity } from "../entities/location.entity";
+
+
+export abstract class LocationRepository {
+    abstract create(createLocationDto: CreateLocationDto): Promise<LocationEntity>;
+    abstract update(updateLocationDto: UpdateLocationDto): Promise<LocationEntity>;
+    abstract deleteHardById(id: number): Promise<LocationEntity>;
+}

--- a/api/src/domain/repositories/reward.repository.ts
+++ b/api/src/domain/repositories/reward.repository.ts
@@ -1,0 +1,12 @@
+import { CreateRewardDto } from "../dtos/rewards/create-reward.dto";
+import { UpdateRewardDto } from "../dtos/rewards/update-reward.dto";
+import { RewardEntity } from "../entities/reward.entity";
+import { PaginatedRewardResponse } from "../interfaces/paginated-reward-res.interface";
+
+
+export abstract class RewardRepository {
+    abstract getAll(): Promise<PaginatedRewardResponse>;
+    abstract create(createRewardDto: CreateRewardDto): Promise<RewardEntity>;
+    abstract updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity>;
+    abstract deleteById(id: number): Promise<RewardEntity>;
+}

--- a/api/src/domain/services/reward-service.ts
+++ b/api/src/domain/services/reward-service.ts
@@ -1,0 +1,6 @@
+import { RewardEntity } from "../entities/reward.entity";
+
+
+export abstract class RewardService {
+    abstract createRewardWithLocation(reward: any): Promise<RewardEntity>;
+}

--- a/api/src/domain/use-cases/location/create-location.ts
+++ b/api/src/domain/use-cases/location/create-location.ts
@@ -1,0 +1,16 @@
+import { CreateLocationDto } from "../../dtos/locations/create-location.dto";
+import { LocationEntity } from "../../entities/location.entity";
+import { LocationRepository } from "../../repositories/location.repository";
+
+export interface CreateLocationUseCase {
+    execute(createLocationDto: CreateLocationDto): Promise<LocationEntity>;
+};
+
+export class CreateLocation {
+
+    constructor(private locationRepository: LocationRepository) {}
+
+    async execute(createLocationDto: CreateLocationDto): Promise<LocationEntity> {
+        return this.locationRepository.create(createLocationDto);
+    }
+}

--- a/api/src/domain/use-cases/reward/create-reward.ts
+++ b/api/src/domain/use-cases/reward/create-reward.ts
@@ -1,0 +1,17 @@
+import { CreateRewardDto } from "../../dtos/rewards/create-reward.dto";
+import { RewardEntity } from "../../entities/reward.entity";
+import { RewardRepository } from "../../repositories/reward.repository";
+
+export interface CreateRewardUseCase {
+    execute(createRewardDto: CreateRewardDto): Promise<RewardEntity>;
+};
+
+
+export class CreateReward {
+
+    constructor(private rewardRepository: RewardRepository) {}
+
+    async execute(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
+        return this.rewardRepository.create(createRewardDto);
+    }
+}

--- a/api/src/infrastructure/datasources/locations/postgres-location.datasource.ts
+++ b/api/src/infrastructure/datasources/locations/postgres-location.datasource.ts
@@ -1,0 +1,83 @@
+import { prisma } from "../../../data/postgres";
+import { CreateLocationDto, CustomError, LocationDatasource, LocationEntity, UpdateLocationDto } from "../../../domain";
+
+export class PostgresLocationDatasource implements LocationDatasource {
+
+    async deleteHardById(id: number): Promise<LocationEntity> {
+        
+        try {
+            
+            const locationExists = await this.existsById(id);
+            if (!locationExists) throw CustomError.notFound(`Location with id ${id} not found`);
+
+            const locationDeleted = await prisma.location.delete({
+                where: {
+                    id
+                }
+            });
+
+            return LocationEntity.fromObject(locationDeleted);
+
+        } catch (error) {
+            throw error;
+        }
+
+    }
+    
+    async create(createLocationDto: CreateLocationDto): Promise<LocationEntity> {
+        
+        try {
+            const location = await prisma.location.create({
+                data: {
+                    ...createLocationDto,
+                }
+            });
+
+            return LocationEntity.fromObject(location);
+        } catch (error) {
+            throw error;
+        }
+
+    }
+    
+    async update(updateLocationDto: UpdateLocationDto): Promise<LocationEntity> {
+        try {
+
+            const locationId = updateLocationDto.id;
+
+            const locationExists = await this.existsById(locationId);
+            if (!locationExists) throw CustomError.notFound(`Location with id ${locationId} not found`);
+
+            const locationData = updateLocationDto.values;
+
+            const location = await prisma.location.update({
+                where: {
+                    id: locationId
+                },
+                data: {
+                    ...locationData
+                }
+            });
+
+            return LocationEntity.fromObject(location);
+        } catch (error) {
+            throw error;
+        }
+    }
+
+    async existsById(id: number): Promise<boolean> {
+        try {
+            const location = await prisma.location.findUnique({
+                where: {
+                    id
+                }
+            });
+
+            return !!location;
+        } catch (error) {
+            throw error;
+        }
+    }
+
+
+}

--- a/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
+++ b/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
@@ -1,0 +1,48 @@
+import { prisma } from "../../../data/postgres";
+import {
+  CreateRewardDto,
+  PaginatedRewardResponse,
+  RewardDatasource,
+  RewardEntity,
+  UpdateRewardDto,
+} from "../../../domain";
+
+export class PostgresRewardDatasource implements RewardDatasource {
+
+    async getAll(): Promise<PaginatedRewardResponse> {
+        throw new Error("Method not implemented.");
+    }
+
+    async create(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
+        
+        try {
+            
+            const reward = await prisma.reward.create({
+                data: {
+                    ...createRewardDto,
+                },
+                include:{
+                    location: true,
+                    comments: true,
+                    pet: true,
+                }
+            });
+
+
+            return RewardEntity.fromObject(reward);
+
+
+        } catch (error) {
+            throw error;
+        }
+
+    }
+
+    async updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity> {
+        throw new Error("Method not implemented.");
+    }
+
+    async deleteById(id: number): Promise<RewardEntity> {
+        throw new Error("Method not implemented.");
+    }
+}

--- a/api/src/infrastructure/repositories/location.repository.ts
+++ b/api/src/infrastructure/repositories/location.repository.ts
@@ -1,0 +1,22 @@
+import { CreateLocationDto, LocationDatasource, LocationEntity, LocationRepository, UpdateLocationDto } from "../../domain";
+
+
+export class LocationRepositoryImpl implements LocationRepository {
+    
+    constructor(
+        private readonly datasource: LocationDatasource,
+    ) {}
+
+    async create(createLocationDto: CreateLocationDto): Promise<LocationEntity> {
+        return this.datasource.create(createLocationDto);
+    }
+    
+    async update(updateLocationDto: UpdateLocationDto): Promise<LocationEntity> {
+        return this.datasource.update(updateLocationDto);
+    }
+
+    async deleteHardById(id: number): Promise<LocationEntity> {
+        return this.datasource.deleteHardById(id);
+    }
+
+}

--- a/api/src/infrastructure/repositories/reward.repository.ts
+++ b/api/src/infrastructure/repositories/reward.repository.ts
@@ -1,0 +1,28 @@
+import {
+  CreateRewardDto,
+  PaginatedRewardResponse,
+  RewardDatasource,
+  RewardEntity,
+  RewardRepository,
+  UpdateRewardDto,
+} from "../../domain";
+
+export class RewardRepositoryImpl implements RewardRepository {
+    constructor(private readonly datasource: RewardDatasource) {}
+
+    async create(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
+        return this.datasource.create(createRewardDto);
+    }
+
+    async updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity> {
+        return this.datasource.updateById(updateRewardDto);
+    }
+
+    async deleteById(id: number): Promise<RewardEntity> {
+        return this.datasource.deleteById(id);
+    }
+
+    async getAll(): Promise<PaginatedRewardResponse> {
+        return this.datasource.getAll();
+    }
+}

--- a/api/src/presentation/middlewares/reward.middleware.ts
+++ b/api/src/presentation/middlewares/reward.middleware.ts
@@ -1,0 +1,38 @@
+import { NextFunction, Request, Response } from "express";
+import { PetRepository, handleError } from "../../domain";
+
+export class RewardMiddleware {
+    constructor(private readonly petRepository: PetRepository) {}
+
+    /**
+     * Middleware function to verify ownership of a pet.
+     *
+     * @param req - The Express request object.
+     * @param res - The Express response object.
+     * @param next - The next middleware function.
+     */
+    public verifyPetOwnership = async (
+        req: Request,
+        res: Response,
+        next: NextFunction
+    ) => {
+            const petId = +req.body.reward.petId;
+            if (!petId) return res.status(400).json({ error: "Missing pet id" });
+
+            const userId = req.body.user.id;
+
+            try {
+            const pet = await this.petRepository.findById(petId);
+
+            if (userId !== pet.ownerId) {
+                return res
+                .status(403)
+                .json({ error: "You are not allowed to perform this action" });
+            }
+
+            next();
+        } catch (error) {
+            handleError(error, res);
+        }
+    };
+}

--- a/api/src/presentation/rewards/controller.ts
+++ b/api/src/presentation/rewards/controller.ts
@@ -1,0 +1,31 @@
+import { Request, Response } from "express";
+import { RewardService, handleError } from "../../domain";
+
+
+export class RewardController {
+
+    constructor(
+        private readonly rewardService: RewardService,
+    ) {}
+
+    public getAll = (req: Request, res: Response) => {
+        res.json({ message: 'Get all rewards' });
+    };
+
+    public create = (req: Request, res: Response) => {
+        
+        this.rewardService.createRewardWithLocation(req.body)
+            .then( reward => res.json(reward))
+            .catch( error => handleError(error, res));
+
+    };
+
+    public updateById = (req: Request, res: Response) => {
+        res.json({ message: 'Update reward by id' });
+    };
+
+    public deleteById = (req: Request, res: Response) => {
+        res.json({ message: 'Delete reward by id' });
+    };
+
+}

--- a/api/src/presentation/rewards/routes.ts
+++ b/api/src/presentation/rewards/routes.ts
@@ -1,0 +1,63 @@
+import { Router } from "express";
+import { RewardController } from "./controller";
+import { RewardServiceImpl } from "../services/reward.service";
+import { PostgresRewardDatasource } from "../../infrastructure/datasources/rewards/postgres-reward.datasource";
+import { PostgresLocationDatasource } from "../../infrastructure/datasources/locations/postgres-location.datasource";
+import { RewardRepositoryImpl } from "../../infrastructure/repositories/reward.repository";
+import { LocationRepositoryImpl } from "../../infrastructure/repositories/location.repository";
+import { AuthMiddleware } from "../middlewares/auth.middleware";
+import { PostgresUserDatasourceImpl } from "../../infrastructure/datasources/users/postgres-user.datasource";
+import { PostgresPermissionDatasourceImpl } from "../../infrastructure/datasources/permissions/postgres-permission.datasource";
+import { envs } from "../../config";
+import { PermissionRepositoryImpl } from "../../infrastructure/repositories/permission.repository";
+import { RewardMiddleware } from "../middlewares/reward.middleware";
+import { PostgresPetDatasourceImpl } from "../../infrastructure/datasources/pets/postgres-pet.datasource";
+import { PetRepositoryImpl } from "../../infrastructure/repositories/pet.repository";
+
+export class RewardRoutes {
+
+    static get routes(): Router {
+
+        const router = Router();
+
+        const permissionDatasource = new PostgresPermissionDatasourceImpl(
+            envs.WEBSERVICE_URL,
+        );
+
+        const permissionRepository = new PermissionRepositoryImpl(
+            permissionDatasource,
+        );
+
+        const rewardDatasource = new PostgresRewardDatasource();
+        const locationDatasource = new PostgresLocationDatasource();
+        const userDatasource = new PostgresUserDatasourceImpl(
+            permissionRepository,
+            envs.WEBSERVICE_URL,
+        );
+        const petDatasource = new PostgresPetDatasourceImpl(
+            envs.WEBSERVICE_URL,
+        );
+
+        const rewardRepository = new RewardRepositoryImpl(rewardDatasource);
+        const locationRepository = new LocationRepositoryImpl(locationDatasource);
+        const petRepository = new PetRepositoryImpl(petDatasource);
+
+        const rewardService = new RewardServiceImpl(
+            rewardRepository,
+            locationRepository,
+        );
+
+        const rewardController = new RewardController(rewardService);
+
+        const authMiddleware = new AuthMiddleware(userDatasource);
+        const rewardMiddleware = new RewardMiddleware(petRepository);
+        
+
+        router.get('/', rewardController.getAll);
+        router.post('/', [authMiddleware.validateJWT, rewardMiddleware.verifyPetOwnership ], rewardController.create);
+        router.put('/', rewardController.updateById);
+        router.delete('/:id', rewardController.deleteById);
+
+        return router
+    }
+}

--- a/api/src/presentation/routes.ts
+++ b/api/src/presentation/routes.ts
@@ -4,6 +4,7 @@ import { PetRoutes } from "./pets/routes";
 import { PermissionRoutes } from "./permissions/routes";
 import { AuthRoutes } from "./auth/routes";
 import { SpeciesRoutes } from "./species/routes";
+import { RewardRoutes } from "./rewards/routes";
 
 
 
@@ -18,6 +19,7 @@ export class AppRoutes {
         router.use('/api/permissions', PermissionRoutes.routes)
         router.use('/api/auth', AuthRoutes.routes)
         router.use('/api/species', SpeciesRoutes.routes)
+        router.use('/api/rewards', RewardRoutes.routes)
 
         return router
     }

--- a/api/src/presentation/services/reward.service.ts
+++ b/api/src/presentation/services/reward.service.ts
@@ -1,0 +1,46 @@
+import { CreateLocation, CreateLocationDto, CreateReward, CreateRewardDto, CustomError, ICreateLocationDto, ICreateRewardDto, LocationRepository, RewardEntity, RewardRepository, RewardService } from '../../domain/';
+
+interface RewardAndLocationData {
+    reward: Omit<ICreateRewardDto, 'locationId'>;
+    location: ICreateLocationDto;
+}
+
+export class RewardServiceImpl implements RewardService {
+    
+    constructor(
+        private readonly rewardRepository: RewardRepository,
+        private readonly locationRepository: LocationRepository,
+    ) {}
+
+    async createRewardWithLocation(data: RewardAndLocationData): Promise<RewardEntity> {
+        
+        let locationId: number | null = null;
+
+        try {
+            
+            const { reward, location } = data;
+
+            const [locationError, createLocationDto] = CreateLocationDto.create(location);
+            if (locationError) throw CustomError.badRequest(locationError);
+
+            locationId = (await new CreateLocation(this.locationRepository).execute(createLocationDto!)).id;
+
+            const [rewardError, createRewardDto] = CreateRewardDto.create({
+                ...reward,
+                locationId,
+            });
+            if (rewardError) throw CustomError.badRequest(rewardError);
+
+            return await new CreateReward(this.rewardRepository).execute(createRewardDto!);
+
+        } catch (error) {
+        
+            if (locationId) {
+                await this.locationRepository.deleteHardById(locationId);
+            }
+
+            throw error;
+        }
+
+    }
+}


### PR DESCRIPTION
Resolves #33

**Requirements:**
- [x] Modify the reward creation endpoint to accept location data (address, city, country) along with reward details.
- [x] Implement logic to create a new location in the database using the provided location details before creating the reward.
- [x] Ensure the reward is linked to the newly created location by storing the location's ID with the reward.

**Acceptance Criteria:**
- Location details provided with reward creation requests result in new locations being created in the database.
- Newly created rewards are correctly linked to the newly created locations.
- Unauthorized users cannot create rewards or locations.

**Refactor:**
- I changed the schema.prisma adding createAt and updated to all entities.
- I added properties  latitude, longitude and description to Location entity to be able to obtain the exact location ["See more details"](https://github.com/System-Garcia/node-pets/compare/dev...create-location-and-reward?expand=1#diff-bc4eca7d21ff96af8c247ecbe052047e012a5f338813cc1f47f729ebc97d40bdR84-R88).


