### PR TITLE
34 reward update including location details

### DIFF
--- a/api/src/domain/index.ts
+++ b/api/src/domain/index.ts
@@ -56,6 +56,7 @@ export * from './interfaces/attachement.interface';
 export * from './interfaces/paginated-species-res.interface';
 export * from './interfaces/paginated-permission-res.interface';
 export * from './interfaces/paginated-reward-res.interface';
+export * from './interfaces/updateRewardAndLocationData.interface';
 
 // Use cases
 export * from './use-cases/user/create-user';
@@ -82,6 +83,7 @@ export * from './use-cases/pet/update-pet';
 export * from './use-cases/location/create-location';
 export * from './use-cases/reward/create-reward';
 export * from './use-cases/reward/delete-reward';
+export * from './use-cases/reward/update-reward';
 
 // Services
 export * from './services/email-service';

--- a/api/src/domain/interfaces/updateRewardAndLocationData.interface.ts
+++ b/api/src/domain/interfaces/updateRewardAndLocationData.interface.ts
@@ -1,0 +1,7 @@
+import { UpdateLocationDto } from "../dtos/locations/update-location.dto";
+import { UpdateRewardDto } from "../dtos/rewards/update-reward.dto";
+
+export interface UpdateRewardAndLocationData {
+    reward: UpdateRewardDto,
+    location: UpdateLocationDto,
+}

--- a/api/src/domain/services/reward-service.ts
+++ b/api/src/domain/services/reward-service.ts
@@ -1,7 +1,9 @@
 import { RewardEntity } from "../entities/reward.entity";
+import { UpdateRewardAndLocationData } from "../interfaces/updateRewardAndLocationData.interface";
 
 
 export abstract class RewardService {
     abstract createRewardWithLocation(reward: any): Promise<RewardEntity>;
     abstract deleteReward(id: number): Promise<RewardEntity>;
+    abstract updateReward(data: UpdateRewardAndLocationData): Promise<RewardEntity>;
 }

--- a/api/src/domain/use-cases/reward/update-reward.ts
+++ b/api/src/domain/use-cases/reward/update-reward.ts
@@ -1,0 +1,19 @@
+import { UpdateRewardDto } from '../../dtos/rewards/update-reward.dto';
+import { RewardEntity } from '../../entities/reward.entity';
+import { RewardRepository } from '../../repositories/reward.repository';
+
+interface UpdateRewardUseCase {
+    execute(rewardData: UpdateRewardDto): Promise<RewardEntity>;
+};
+
+
+export class UpdateReward implements UpdateRewardUseCase {
+
+    constructor(
+        private readonly repository: RewardRepository
+    ) {}
+
+    async execute(rewardData: UpdateRewardDto): Promise<RewardEntity> {
+        return this.repository.updateById(rewardData);
+    }
+}

--- a/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
+++ b/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
@@ -9,115 +9,253 @@ import {
 } from "../../../domain";
 
 export class PostgresRewardDatasource implements RewardDatasource {
+  async getAll(): Promise<PaginatedRewardResponse> {
+    throw new Error("Method not implemented.");
+  }
 
-    async getAll(): Promise<PaginatedRewardResponse> {
-        throw new Error("Method not implemented.");
+  async create(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
+    try {
+      const reward = await prisma.reward.create({
+        data: {
+          ...createRewardDto,
+        },
+        include: {
+          location: {
+            select: {
+              id: true,
+              address: true,
+              country: true,
+              city: true,
+              latitude: true,
+              longitude: true,
+              description: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          comments: {
+            select: {
+              id: true,
+              rewardId: true,
+              userId: true,
+              text: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          pet: {
+            select: {
+              id: true,
+              ownerId: true,
+              name: true,
+              speciesId: true,
+              color: true,
+              img: true,
+              missingAt: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
+
+      return RewardEntity.fromObject(reward);
+    } catch (error) {
+      throw error;
     }
+  }
 
-    async create(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
-        
-        try {
-            
-            const reward = await prisma.reward.create({
-                data: {
-                    ...createRewardDto,
-                },
-                include:{
-                    location: true,
-                    comments: true,
-                    pet: true,
-                }
-            });
+  async updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity> {
+    try {
+      const rewardExists = await this.verifiyRewardExists(updateRewardDto.id);
+      if (!rewardExists) {
+        throw CustomError.notFound(
+          `Reward with id ${updateRewardDto.id} not found`
+        );
+      }
 
+      const reward = await prisma.reward.update({
+        where: {
+          id: updateRewardDto.id,
+        },
+        data: {
+          ...updateRewardDto,
+        },
+        include: {
+          location: {
+            select: {
+              id: true,
+              address: true,
+              country: true,
+              city: true,
+              latitude: true,
+              longitude: true,
+              description: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          comments: {
+            select: {
+              id: true,
+              rewardId: true,
+              userId: true,
+              text: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          pet: {
+            select: {
+              id: true,
+              ownerId: true,
+              name: true,
+              speciesId: true,
+              color: true,
+              img: true,
+              missingAt: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
 
-            return RewardEntity.fromObject(reward);
-
-
-        } catch (error) {
-            throw error;
-        }
-
+      return RewardEntity.fromObject(reward);
+    } catch (error) {
+      throw error;
     }
+  }
 
-    async updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity> {
-        throw new Error("Method not implemented.");
+  async deleteById(id: number): Promise<RewardEntity> {
+    try {
+      const rewardExists = await this.verifiyRewardExists(id);
+      if (!rewardExists) {
+        throw CustomError.notFound(`Reward with id ${id} not found`);
+      }
+
+      const rewardDeleted = await prisma.reward.update({
+        where: {
+          id,
+        },
+        data: {
+          isDeleted: true,
+        },
+        include: {
+          location: {
+            select: {
+              id: true,
+              address: true,
+              country: true,
+              city: true,
+              latitude: true,
+              longitude: true,
+              description: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          comments: {
+            select: {
+              id: true,
+              rewardId: true,
+              userId: true,
+              text: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          pet: {
+            select: {
+              id: true,
+              ownerId: true,
+              name: true,
+              speciesId: true,
+              color: true,
+              img: true,
+              missingAt: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
+
+      return RewardEntity.fromObject(rewardDeleted);
+    } catch (error) {
+      throw error;
     }
+  }
 
-    async deleteById(id: number): Promise<RewardEntity> {
-        
-        try {
-            
-            const rewardExists = await this.verifiyRewardExists(id);
-            if (!rewardExists) {
-                throw CustomError.notFound(`Reward with id ${id} not found`);
-            }
+  async findById(id: number): Promise<RewardEntity> {
+    try {
+      const reward = await prisma.reward.findUnique({
+        where: {
+          id,
+          isDeleted: false,
+        },
+        include: {
+          location: {
+            select: {
+              id: true,
+              address: true,
+              country: true,
+              city: true,
+              latitude: true,
+              longitude: true,
+              description: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          comments: {
+            select: {
+              id: true,
+              rewardId: true,
+              userId: true,
+              text: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+          pet: {
+            select: {
+              id: true,
+              ownerId: true,
+              name: true,
+              speciesId: true,
+              color: true,
+              img: true,
+              missingAt: true,
+              createdAt: true,
+              updatedAt: true,
+            },
+          },
+        },
+      });
 
-            const rewardDeleted = await prisma.reward.update({
-                where: {
-                    id,
-                },
-                data: {
-                    isDeleted: true,
-                },
-                include:{
-                    location: true,
-                    comments: true,
-                    pet: true,
-                }
-            });
+      if (!reward) {
+        throw CustomError.notFound("Reward not found");
+      }
 
-            return RewardEntity.fromObject(rewardDeleted);
-
-        } catch (error) {
-            throw error;
-        }
-
+      return RewardEntity.fromObject(reward);
+    } catch (error) {
+      throw error;
     }
+  }
 
-    async findById(id: number): Promise<RewardEntity> {
-        
-        try {
-            
-            const reward = await prisma.reward.findUnique({
-                where: {
-                    id,
-                    isDeleted: false,
-                },
-                include:{
-                    location: true,
-                    comments: true,
-                    pet: true,
-                }
-            });
+  async verifiyRewardExists(id: number): Promise<boolean> {
+    try {
+      const reward = await prisma.reward.findUnique({
+        where: {
+          id,
+          isDeleted: false,
+        },
+      });
 
-            if (!reward) {
-                throw CustomError.notFound('Reward not found');
-            }
-            
-            return RewardEntity.fromObject(reward);
-
-        } catch (error) {
-            throw error;
-        }
-
+      return !!reward;
+    } catch (error) {
+      throw error;
     }
-
-    async verifiyRewardExists(id: number): Promise<boolean> {
-            
-        try {
-            
-            const reward = await prisma.reward.findUnique({
-                where: {
-                    id,
-                    isDeleted: false,
-                }
-            });
-
-            return !!reward;
-
-        } catch (error) {
-            throw error;
-        }
-    
-    }
+  }
 }

--- a/api/src/presentation/middlewares/reward.middleware.ts
+++ b/api/src/presentation/middlewares/reward.middleware.ts
@@ -57,6 +57,8 @@ export class RewardMiddleware {
                 .status(403)
                 .json({ error: "You are not allowed to perform this action" });
             }
+            
+            res.locals.reward = reward;
 
             next();
         } catch (error) {

--- a/api/src/presentation/rewards/controller.ts
+++ b/api/src/presentation/rewards/controller.ts
@@ -21,7 +21,20 @@ export class RewardController {
     };
 
     public updateById = (req: Request, res: Response) => {
-        res.json({ message: 'Update reward by id' });
+
+        const reward = {
+            id: +req.params.id,
+            ...req.body.reward,
+        }
+        
+        const location = {
+            id: res.locals.reward.location.id,
+            ...req.body.location,
+        };
+
+        this.rewardService.updateReward({reward, location})
+            .then( reward => res.json(reward))
+            .catch( error => handleError(error, res));
     };
 
     public deleteById = (req: Request, res: Response) => {

--- a/api/src/presentation/rewards/routes.ts
+++ b/api/src/presentation/rewards/routes.ts
@@ -55,7 +55,7 @@ export class RewardRoutes {
 
         router.get('/', rewardController.getAll);
         router.post('/', [authMiddleware.validateJWT, rewardMiddleware.verifyPetOwnership ], rewardController.create);
-        router.put('/', rewardController.updateById);
+        router.put('/:id', [authMiddleware.validateJWT, rewardMiddleware.verifyRewardOwnership ],rewardController.updateById);
         router.delete('/:id', [ authMiddleware.validateJWT, rewardMiddleware.verifyRewardOwnership ], rewardController.deleteById);
 
         return router

--- a/api/src/presentation/services/reward.service.ts
+++ b/api/src/presentation/services/reward.service.ts
@@ -1,3 +1,4 @@
+import { UpdateLocationDto } from '../../domain/dtos/locations/update-location.dto';
 import {
   CreateLocation,
   CreateLocationDto,
@@ -11,6 +12,8 @@ import {
   RewardEntity,
   RewardRepository,
   RewardService,
+  UpdateRewardAndLocationData,
+  UpdateRewardDto,
 } from "../../domain/";
 
 interface RewardAndLocationData {
@@ -23,6 +26,26 @@ export class RewardServiceImpl implements RewardService {
     private readonly rewardRepository: RewardRepository,
     private readonly locationRepository: LocationRepository
   ) {}
+  
+  async updateReward(data: UpdateRewardAndLocationData): Promise<RewardEntity> {
+    
+    const { reward, location } = data;
+    
+    const [locationError, updateLocationDto] = UpdateLocationDto.create(location);
+    if (locationError) throw CustomError.badRequest(locationError);
+
+    const [rewardError, updateRewardDto] = UpdateRewardDto.create({
+      ...reward,
+      locationId: +updateLocationDto!.id,
+    });
+
+    if (rewardError) throw CustomError.badRequest(rewardError);
+
+    console.log(updateRewardDto);
+
+    throw new Error("Method not implemented.");
+
+  }
 
   async createRewardWithLocation(
     data: RewardAndLocationData

--- a/api/src/presentation/services/reward.service.ts
+++ b/api/src/presentation/services/reward.service.ts
@@ -41,9 +41,9 @@ export class RewardServiceImpl implements RewardService {
 
     if (rewardError) throw CustomError.badRequest(rewardError);
 
-    console.log(updateRewardDto);
+    this.locationRepository.update(updateLocationDto!);
 
-    throw new Error("Method not implemented.");
+    return this.rewardRepository.updateById(updateRewardDto!);
 
   }
 


### PR DESCRIPTION
Resolves #34 

**Acceptance Criteria:**
- Users can update reward details and associated location information in one request.
- Only the reward owner can update the reward and its location.
- All input data is validated to ensure integrity and correctness.
