### PR TITLE
Create a Public API Endpoint for Fetching Reward Details

### DIFF
--- a/api/src/domain/datasources/reward.datasource.ts
+++ b/api/src/domain/datasources/reward.datasource.ts
@@ -1,12 +1,13 @@
 import { CreateRewardDto } from "../dtos/rewards/create-reward.dto";
 import { UpdateRewardDto } from "../dtos/rewards/update-reward.dto";
+import { PaginationDto } from "../dtos/shared/pagination.dto";
 import { RewardEntity } from "../entities/reward.entity";
 import { PaginatedRewardResponse } from "../interfaces/paginated-reward-res.interface";
 
 
 export abstract class RewardDatasource {
     
-    abstract getAll(): Promise<PaginatedRewardResponse>;
+    abstract getAll(paginationDto: PaginationDto): Promise<PaginatedRewardResponse>;
     abstract create(createRewardDto: CreateRewardDto): Promise<RewardEntity>;
     abstract updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity>;
     abstract deleteById(id: number): Promise<RewardEntity>;

--- a/api/src/domain/repositories/reward.repository.ts
+++ b/api/src/domain/repositories/reward.repository.ts
@@ -1,11 +1,12 @@
 import { CreateRewardDto } from "../dtos/rewards/create-reward.dto";
 import { UpdateRewardDto } from "../dtos/rewards/update-reward.dto";
+import { PaginationDto } from "../dtos/shared/pagination.dto";
 import { RewardEntity } from "../entities/reward.entity";
 import { PaginatedRewardResponse } from "../interfaces/paginated-reward-res.interface";
 
 
 export abstract class RewardRepository {
-    abstract getAll(): Promise<PaginatedRewardResponse>;
+    abstract getAll(paginationDto: PaginationDto): Promise<PaginatedRewardResponse>;
     abstract create(createRewardDto: CreateRewardDto): Promise<RewardEntity>;
     abstract updateById(updateRewardDto: UpdateRewardDto): Promise<RewardEntity>;
     abstract deleteById(id: number): Promise<RewardEntity>;

--- a/api/src/domain/services/reward-service.ts
+++ b/api/src/domain/services/reward-service.ts
@@ -1,4 +1,6 @@
+import { PaginationDto } from "../dtos/shared/pagination.dto";
 import { RewardEntity } from "../entities/reward.entity";
+import { PaginatedRewardResponse } from "../interfaces/paginated-reward-res.interface";
 import { UpdateRewardAndLocationData } from "../interfaces/updateRewardAndLocationData.interface";
 
 
@@ -6,4 +8,5 @@ export abstract class RewardService {
     abstract createRewardWithLocation(reward: any): Promise<RewardEntity>;
     abstract deleteReward(id: number): Promise<RewardEntity>;
     abstract updateReward(data: UpdateRewardAndLocationData): Promise<RewardEntity>;
+    abstract getAll(paginationDto: PaginationDto) : Promise<PaginatedRewardResponse>
 }

--- a/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
+++ b/api/src/infrastructure/datasources/rewards/postgres-reward.datasource.ts
@@ -3,14 +3,95 @@ import {
   CreateRewardDto,
   CustomError,
   PaginatedRewardResponse,
+  PaginationDto,
   RewardDatasource,
   RewardEntity,
   UpdateRewardDto,
 } from "../../../domain";
 
+const rewardInclude = {
+  location: {
+    select: {
+      id: true,
+      address: true,
+      country: true,
+      city: true,
+      latitude: true,
+      longitude: true,
+      description: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  },
+  comments: {
+    select: {
+      id: true,
+      rewardId: true,
+      userId: true,
+      text: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  },
+  pet: {
+    select: {
+      id: true,
+      ownerId: true,
+      name: true,
+      speciesId: true,
+      color: true,
+      img: true,
+      missingAt: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+  },
+};
+
 export class PostgresRewardDatasource implements RewardDatasource {
-  async getAll(): Promise<PaginatedRewardResponse> {
-    throw new Error("Method not implemented.");
+
+  constructor(private readonly webServiceUrl: string) {}
+
+  async getAll(paginationDto: PaginationDto): Promise<PaginatedRewardResponse> {
+    
+    const { page, limit } = paginationDto;
+
+    try {
+      const skip = (page - 1) * limit;
+
+      const [total, rewards] = await Promise.all([
+        prisma.reward.count(),
+        prisma.reward.findMany({
+          where: { isDeleted: false },
+          include: {
+            ...rewardInclude,
+          },
+          skip: skip,
+          take: limit,
+        }),
+      ]);
+
+      const nextPage =
+        page * limit >= total
+          ? null
+          : `${this.webServiceUrl}/rewards?page=${page + 1}&limit=${limit}`;
+
+      const prevPage =
+        page - 1 > 0
+          ? `${this.webServiceUrl}/rewards?page=${page - 1}&limit=${limit}`
+          : null;
+
+      return {
+        page,
+        limit,
+        total,
+        next: nextPage,
+        prev: prevPage,
+        rewards: rewards.map((reward) => RewardEntity.fromObject(reward)),
+      };
+    } catch (error) {
+      throw error;
+    }
   }
 
   async create(createRewardDto: CreateRewardDto): Promise<RewardEntity> {
@@ -20,42 +101,7 @@ export class PostgresRewardDatasource implements RewardDatasource {
           ...createRewardDto,
         },
         include: {
-          location: {
-            select: {
-              id: true,
-              address: true,
-              country: true,
-              city: true,
-              latitude: true,
-              longitude: true,
-              description: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          comments: {
-            select: {
-              id: true,
-              rewardId: true,
-              userId: true,
-              text: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          pet: {
-            select: {
-              id: true,
-              ownerId: true,
-              name: true,
-              speciesId: true,
-              color: true,
-              img: true,
-              missingAt: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
+          ...rewardInclude,
         },
       });
 
@@ -82,42 +128,7 @@ export class PostgresRewardDatasource implements RewardDatasource {
           ...updateRewardDto,
         },
         include: {
-          location: {
-            select: {
-              id: true,
-              address: true,
-              country: true,
-              city: true,
-              latitude: true,
-              longitude: true,
-              description: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          comments: {
-            select: {
-              id: true,
-              rewardId: true,
-              userId: true,
-              text: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          pet: {
-            select: {
-              id: true,
-              ownerId: true,
-              name: true,
-              speciesId: true,
-              color: true,
-              img: true,
-              missingAt: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
+          ...rewardInclude,
         },
       });
 
@@ -142,42 +153,7 @@ export class PostgresRewardDatasource implements RewardDatasource {
           isDeleted: true,
         },
         include: {
-          location: {
-            select: {
-              id: true,
-              address: true,
-              country: true,
-              city: true,
-              latitude: true,
-              longitude: true,
-              description: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          comments: {
-            select: {
-              id: true,
-              rewardId: true,
-              userId: true,
-              text: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          pet: {
-            select: {
-              id: true,
-              ownerId: true,
-              name: true,
-              speciesId: true,
-              color: true,
-              img: true,
-              missingAt: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
+          ...rewardInclude,
         },
       });
 
@@ -195,42 +171,7 @@ export class PostgresRewardDatasource implements RewardDatasource {
           isDeleted: false,
         },
         include: {
-          location: {
-            select: {
-              id: true,
-              address: true,
-              country: true,
-              city: true,
-              latitude: true,
-              longitude: true,
-              description: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          comments: {
-            select: {
-              id: true,
-              rewardId: true,
-              userId: true,
-              text: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
-          pet: {
-            select: {
-              id: true,
-              ownerId: true,
-              name: true,
-              speciesId: true,
-              color: true,
-              img: true,
-              missingAt: true,
-              createdAt: true,
-              updatedAt: true,
-            },
-          },
+          ...rewardInclude,
         },
       });
 

--- a/api/src/infrastructure/repositories/reward.repository.ts
+++ b/api/src/infrastructure/repositories/reward.repository.ts
@@ -1,6 +1,7 @@
 import {
   CreateRewardDto,
   PaginatedRewardResponse,
+  PaginationDto,
   RewardDatasource,
   RewardEntity,
   RewardRepository,
@@ -22,8 +23,8 @@ export class RewardRepositoryImpl implements RewardRepository {
         return this.datasource.deleteById(id);
     }
 
-    async getAll(): Promise<PaginatedRewardResponse> {
-        return this.datasource.getAll();
+    async getAll(paginationDto: PaginationDto): Promise<PaginatedRewardResponse> {
+        return this.datasource.getAll(paginationDto);
     }
 
     async findById(id: number): Promise<RewardEntity> {

--- a/api/src/presentation/rewards/controller.ts
+++ b/api/src/presentation/rewards/controller.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { RewardService, handleError } from "../../domain";
+import { PaginationDto, RewardService, handleError } from "../../domain";
 
 
 export class RewardController {
@@ -9,7 +9,16 @@ export class RewardController {
     ) {}
 
     public getAll = (req: Request, res: Response) => {
-        res.json({ message: 'Get all rewards' });
+        
+        const { page = 1, limit = 10} = req.query;
+
+        const [error, paginationDto] = PaginationDto.create(+page, +limit);
+        if (error) return res.status(400).json({ error });
+        
+        this.rewardService.getAll(paginationDto!)
+            .then( rewards => res.json(rewards))
+            .catch( error => handleError(error, res));
+
     };
 
     public create = (req: Request, res: Response) => {

--- a/api/src/presentation/rewards/routes.ts
+++ b/api/src/presentation/rewards/routes.ts
@@ -28,7 +28,7 @@ export class RewardRoutes {
             permissionDatasource,
         );
 
-        const rewardDatasource = new PostgresRewardDatasource();
+        const rewardDatasource = new PostgresRewardDatasource(envs.WEBSERVICE_URL);
         const locationDatasource = new PostgresLocationDatasource();
         const userDatasource = new PostgresUserDatasourceImpl(
             permissionRepository,

--- a/api/src/presentation/services/reward.service.ts
+++ b/api/src/presentation/services/reward.service.ts
@@ -9,6 +9,8 @@ import {
   ICreateLocationDto,
   ICreateRewardDto,
   LocationRepository,
+  PaginatedRewardResponse,
+  PaginationDto,
   RewardEntity,
   RewardRepository,
   RewardService,
@@ -26,6 +28,12 @@ export class RewardServiceImpl implements RewardService {
     private readonly rewardRepository: RewardRepository,
     private readonly locationRepository: LocationRepository
   ) {}
+
+  getAll(paginationDto: PaginationDto): Promise<PaginatedRewardResponse> {
+    
+    return this.rewardRepository.getAll(paginationDto);
+
+  }
   
   async updateReward(data: UpdateRewardAndLocationData): Promise<RewardEntity> {
     


### PR DESCRIPTION
Resloves #80 

**Objective:** Develop a public endpoint to retrieve reward information, accessible without user authentication.

**Requirements:**
- [x] Create a public-facing GET endpoint for fetching rewards.
- [x] Implement reward retrieval logic that includes relevant details like reward title, description, and associated location information.
- [x] Optimize the data retrieval using Prisma's selective `include` or `select` queries to efficiently fetch necessary data while excluding sensitive information.

**Acceptance Criteria:**
- Public users can fetch reward details without needing to authenticate.
- The API endpoint returns only non-sensitive reward and associated location data, ensuring privacy and security.
- The retrieval process is optimized to handle potentially large datasets efficiently, ensuring good performance.
